### PR TITLE
feat(container): add `container.has()` method

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -239,6 +239,10 @@ export class Container {
     }
   }
 
+  public has<T>(token: Token<T>): boolean {
+    return this.providers.has(token);
+  }
+
   private construct<T>(provider: Provider<T>, scope: Container = this): T[] {
     const originalScope = currentScope;
     try {


### PR DESCRIPTION
I think it would be nice to have a container.has method that actually does not instantiate the related provider and returns true if a token is bound. My workaround so far was `if (!container.get(TOKEN, { optional: true }))` but that creates the singleton if available and not yet created. 

The need for this functionality is purely sveltekit development based and does not happen in production: When I create a container in a layout.svelte and use HMR in dev mode, only parts of the application are getting reloaded when I change code. This quite often leads to "token xyz is already bound to the container", so I wanted to check first if the token exists already, but of course without creating the singleton already.